### PR TITLE
Update Dehydrated and Alpine Versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ VOLUME '/dehydrated/accounts'
 VOLUME '/dehydrated/chains'
 VOLUME '/dehydrated/domains.txt'
 
-ENTRYPOINT /entrypont.sh
+ENTRYPOINT ["/entrypont.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apk add --update --no-cache gcc build-base python3-dev libffi-dev libressl-d
     mv /dehydrated-${DEHYDRATED_VERSION} /dehydrated && \
     mkdir -p /dehydrated/hooks /dehydrated/certs /dehydrated/accounts && \
     pip install --no-cache-dir dns-lexicon && \
-    rm -rf /var/cache/apk/* ~/.cache
+    rm -rf /var/cache/apk/* ~/.cache /root/.cargo && \
+    apk del --no-cache gcc build-base python3-dev libffi-dev libressl-dev openssl-dev musl-dev rust cargo
 
 # Add necessary script to the image.
 COPY entrypoint.sh /entrypont.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ COPY dehydrated.default.sh /dehydrated/hooks/dehydrated.default.sh
 # Ensure the required permissions on the executables.
 RUN chmod +x /dehydrated/hooks/dehydrated.default.sh && \
     chmod +x /entrypont.sh && \
-    chmod +x /dehydrated/dehydrated
+    chmod +x /dehydrated/dehydrated && \
+    chmod +w /dehydrated
 
 # Provider to be used on lexicon.
 # See a list of allowed provider on the project page.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM python:alpine
 LABEL maintainer="gabriel@melillo.me"
 
 # Variables needed on setup
-ARG DEHYDRATED_VERSION="0.6.5"
+ARG DEHYDRATED_VERSION="0.7.0"
 
 # Setup the environment
 RUN apk add --update --no-cache gcc build-base python3-dev libffi-dev libressl-dev curl openssl openssl-dev musl-dev rust cargo bash && \
-    curl -L https://github.com/lukas2511/dehydrated/archive/v${DEHYDRATED_VERSION}.tar.gz | tar -xz -C / && \
+    curl -L https://github.com/dehydrated-io/dehydrated/archive/v${DEHYDRATED_VERSION}.tar.gz | tar -xz -C / && \
     mv /dehydrated-${DEHYDRATED_VERSION} /dehydrated && \
     mkdir -p /dehydrated/hooks /dehydrated/certs /dehydrated/accounts && \
     pip install --no-cache-dir dns-lexicon && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.0b1-alpine3.9
+FROM python:alpine
 
 LABEL maintainer="gabriel@melillo.me"
 
@@ -6,7 +6,7 @@ LABEL maintainer="gabriel@melillo.me"
 ARG DEHYDRATED_VERSION="0.6.5"
 
 # Setup the environment
-RUN apk add --update --no-cache gcc build-base python3-dev libffi-dev libressl-dev curl openssl bash && \
+RUN apk add --update --no-cache gcc build-base python3-dev libffi-dev libressl-dev curl openssl openssl-dev musl-dev rust cargo bash && \
     curl -L https://github.com/lukas2511/dehydrated/archive/v${DEHYDRATED_VERSION}.tar.gz | tar -xz -C / && \
     mv /dehydrated-${DEHYDRATED_VERSION} /dehydrated && \
     mkdir -p /dehydrated/hooks /dehydrated/certs /dehydrated/accounts && \


### PR DESCRIPTION
**Update Dehydrated to 0.7.0**
Upgrade Dehydrated and change the URL it is downloaded from since the
repo moved.

**Fix Issue with Container Not Building**
Due to new requirements by PyCA, a dependency of dns-lexicon the
Dockerfile must now be based on a newer version of alpine and install
the Rust toolchain.

**Reduce Container Size**
Remove the build-time dependencies from the image before the next phase
so that the overall container size is much smaller.

**Change ENTRYPOINT to Exec Form to Allow Arguments**
By changing ENTRYPOINT from the shell form to the exec form it is now
possible to supply additional arguments to dehydrated from the
command-line (e.g. --force).

**Allow Dehydrated to Run As Non-Root User**
By making the dehydrated working directory writable by anyone, it is now
possible to run the docker container as any user.

Example:
docker run --it --rm --name letsencrypt \
  --user 1000:1000 \
  -v "$(pwd)/certs:/dehydrated/certs" \
  -v "$(pwd)/domains.txt:/dehydrated/domains.txt" \
  -v "$(pwd)/accounts:/dehydrated/accounts" \
  -v "$(pwd)/chains:/dehydrated/chains" \
  -e LEXICON_DIGITALOCEAN_TOKEN="DO_TOKEN_GENERATED_ON_THE_SITE" \
  -e PROVIDER="digitalocean" \
  gmelillo/dehydrated-lexicon:latest